### PR TITLE
Track support

### DIFF
--- a/dodgeball_test.go
+++ b/dodgeball_test.go
@@ -27,7 +27,7 @@ func TestDodgeball_Checkpoint(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"test1", fields{"secret", &config}, args{CheckpointRequest{
+		{"checkpoint test1", fields{"secret", &config}, args{CheckpointRequest{
 			CheckpointName: "test",
 			Event: CheckpointEvent{
 				IP:   "123.123.123.123",
@@ -38,7 +38,7 @@ func TestDodgeball_Checkpoint(t *testing.T) {
 			UserID:            "userID",
 			UseVerificationID: "verifyID",
 		}}, false},
-		{"test2", fields{"secret", &configDisabled}, args{CheckpointRequest{
+		{"checkpoint test2", fields{"secret", &configDisabled}, args{CheckpointRequest{
 			CheckpointName: "test",
 			Event: CheckpointEvent{
 				IP:   "123.123.123.123",
@@ -58,6 +58,49 @@ func TestDodgeball_Checkpoint(t *testing.T) {
 			}
 			if _, err := d.Checkpoint(tt.args.request); (err != nil) != tt.wantErr {
 				t.Errorf("Dodgeball.Checkpoint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDodgeball_Track(t *testing.T) {
+	type fields struct {
+		secret string
+		config *Config
+	}
+	type args struct {
+		request TrackOptions
+	}
+	config := Config{
+		APIURL:     "https://api.dodgeballhq.com/",
+		APIVersion: "v1",
+		IsEnabled:  true,
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{"track test1", fields{"secret", &config}, args{TrackOptions{
+			Event: TrackEvent{
+				Type: "testtracktype",
+				Data: nil,
+			},
+			SourceToken: "dodgeballID",
+			SessionID:   "sessionID",
+			UserID:      "userID",
+		}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Dodgeball{
+				secret: tt.fields.secret,
+				config: tt.fields.config,
+			}
+			if err := d.Track(tt.args.request); (err != nil) != tt.wantErr {
+				t.Errorf("Dodgeball.Track() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/track.go
+++ b/track.go
@@ -1,0 +1,14 @@
+package dodgeball
+
+type TrackEvent struct {
+	Type      string      `json:"type"`      // The name of the event, may be any string under 256 characters, that indicates what took place
+	Data      interface{} `json:"data"`      // Any arbitrary data they want to track. Will be digested into the Dodgeball Vocabulary
+	EventTime int64       `json:"eventTime"` // The time the event occurred, in milliseconds since the epoch
+}
+
+type TrackOptions struct {
+	Event       TrackEvent `json:"event"`
+	SourceToken string     `json:"sourceToken"`
+	UserID      string     `json:"userId"`
+	SessionID   string     `json:"sessionId"`
+}


### PR DESCRIPTION
This PR adds support for the new Track endpoint.

You can track additional information about a user's journey by submitting tracking events from your server. This information will be added to the user's profile and is made available to checkpoints.